### PR TITLE
Add gitattributes for unix lf replacement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,13 @@
 # You should use this for files that must keep LF endings, even on Windows and OSX.
 * text eol=lf
 
+*.txt text
+*.Rmd text
+*.csv text
+*.md text
+*.Rproj text
+*.xml text
+
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Git will always convert line endings to LF on checkout. 
 # You should use this for files that must keep LF endings, even on Windows and OSX.
-text eol=lf
+* text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Git will always convert line endings to LF on checkout. 
+# You should use this for files that must keep LF endings, even on Windows and OSX.
+text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+
+

--- a/knb-lter-nes.23.2.xml
+++ b/knb-lter-nes.23.2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<eml:eml xmlns:eml="https://eml.ecoinformatics.org/eml-2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.2" packageId="knb-lter-nes.23.1" xsi:schemaLocation="https://eml.ecoinformatics.org/eml-2.2.0/eml.xsd https://eml.ecoinformatics.org/eml-2.2.0/eml.xsd" system="edi">
+<eml:eml xmlns:eml="https://eml.ecoinformatics.org/eml-2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.2" packageId="knb-lter-nes.23.2" xsi:schemaLocation="https://eml.ecoinformatics.org/eml-2.2.0/eml.xsd https://eml.ecoinformatics.org/eml-2.2.0/eml.xsd" system="edi">
   <access authSystem="https://pasta.edirepository.org/authentication" order="allowFirst" scope="document">
     <allow>
       <principal>uid=NES,o=LTER,dc=ecoinformatics,dc=org</principal>
@@ -60,7 +60,7 @@
       <userId directory="https://orcid.org">https://orcid.org/0000-0002-2903-5851</userId>
       <role>Metadata Provider</role>
     </associatedParty>
-    <pubDate>2022-11-29</pubDate>
+    <pubDate>2023-03-28</pubDate>
     <abstract>
       <para>Dissolved organic carbon and dissolved total nitrogen are measured from discrete bottle samples collected during CTD-rosette casts on Northeast U.S. Shelf Long-Term Ecological Research (NES-LTER) Transect cruises (ongoing since 2022). Sampling frequency is approximately seasonal. Sample collection is paired with particulate organic carbon at surface, subsurface chlorophyll max, and sometimes a third depth. Samples are filtered directly from the CTD rosette and acidified in the field, then analyzed using a Shimadzu TOC-LCPH total organic carbon analyzer coupled to a TNM-L analyzer for total nitrogen. Values are reported in micromoles per liter. </para>
     </abstract>
@@ -141,7 +141,7 @@
           <para># Data Cleaning and Assembly</para>
           <para>Sample metadata were combined with lab results by concatenating cruises called from the REST API of the NES-LTER data system. Nearest station uses a specific station list including NES-LTER standard stations L1 to L11 and the Martha's Vineyard Coastal Observatory (MVCO). Further documentation can be found on GitHub, at https://github.com/WHOIGit/nes-lter-doc-transect. </para>
           <para># Quality Assurance</para>
-          <para>We assured that the geographic and temporal coverage of the clean data table were within expected ranges. In addition to checking replicate samples mentioned above, the carbon to nitrogen ratio was examined. Data of good quality, flagged as 1, are included in the table.&#13;
+          <para>We assured that the geographic and temporal coverage of the clean data table were within expected ranges. In addition to checking replicate samples mentioned above, the carbon to nitrogen ratio was examined. Data of good quality, flagged as 1, are included in the table.
 </para>
         </description>
       </methodStep>
@@ -250,12 +250,12 @@
       <entityDescription>DOC and DTN from discrete water column samples on NES-LTER cruises</entityDescription>
       <physical>
         <objectName>nes-lter-doc-transect.csv</objectName>
-        <size unit="bytes">11206</size>
-        <authentication method="MD5">97e552b86e8c4951104b7cccc4e25460</authentication>
+        <size unit="bytes">11106</size>
+        <authentication method="MD5">d260df8f4f31906feb1f1749b5009985</authentication>
         <dataFormat>
           <textFormat>
             <numHeaderLines>1</numHeaderLines>
-            <recordDelimiter>\r\n</recordDelimiter>
+            <recordDelimiter>\n</recordDelimiter>
             <attributeOrientation>column</attributeOrientation>
             <simpleDelimited>
               <fieldDelimiter>,</fieldDelimiter>

--- a/nes-lter-doc-transect.Rmd
+++ b/nes-lter-doc-transect.Rmd
@@ -31,7 +31,7 @@ Read the Excel metadata template and generate text templates used by
 EMLassemblyline
 
 ```{r}
-excel_to_template(here("nes-lter-doc-transect-info"), "nes-lter-doc-transect", rights="CC0", other_info= TRUE, data_table=data_table)
+excel_to_template(here("nes-lter-doc-transect-info"), "nes-lter-doc-transect", rights="CC0", data_table=data_table)
 ```
 Generate the package and insert the parent project node into the resulting EML
 

--- a/nes-lter-doc-transect.Rmd
+++ b/nes-lter-doc-transect.Rmd
@@ -36,7 +36,7 @@ excel_to_template(here("nes-lter-doc-transect-info"), "nes-lter-doc-transect", r
 Generate the package and insert the parent project node into the resulting EML
 
 ```{r}
-pkg_id <- "knb-lter-nes.23.1"
+pkg_id <- "knb-lter-nes.23.2"
 
 make_eml(here(),
          dataset.title="Dissolved Organic Carbon (DOC) and Dissolved Total Nitrogen (DTN) from Northeast U.S. Shelf Long Term Ecological Research (NES-LTER) Transect cruises, ongoing since 2022",

--- a/nes-lter-doc-transect.Rmd
+++ b/nes-lter-doc-transect.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "Minimal EDI package generated using EMLassemblyline and ediutilities"
+title: "Dissolved Organic Carbon and Dissolved Total Nitrogen"
 author: "Joe Futrelle"
-date: "2022-01-24"
+date: "2023-03-28"
 output:
   html_document:
     df_print: paged


### PR DESCRIPTION
Changes:

1. Add .gitattributes to repo
2. Delete other_info parameter from call to excel_to_template. This was causing an error.
3. Increase package id number.

In order to test changing CRLF to LF on github commit:
Commit #5d55ffd manually changes LF to CRLF  in nes-lter-doc-transect.RMD and you can see diffs on every line.
Commit #8c4a25a changes CRLF back to LF automatically using git commit in nes-lter-doc-transect.RMD and you can see the diffs on every line.

As expected, on the final commit there are only diffs in nes-lter-doc-transect.RMD where changes were made. There are no CRLF diffs.